### PR TITLE
Make nether blocks invisible for xray

### DIFF
--- a/resource_packs/fluoroscopy/subpacks/xray/blocks.json
+++ b/resource_packs/fluoroscopy/subpacks/xray/blocks.json
@@ -1,6 +1,15 @@
 {
   "format_version": "1.19.30",
+  "basalt": {
+    "blockshape": "invisible"
+  },
+  "blackstone": {
+    "blockshape": "invisible"
+  },
   "clay": {
+    "blockshape": "invisible"
+  },
+  "crimson_nylium": {
     "blockshape": "invisible"
   },
   "deepslate": {
@@ -21,10 +30,16 @@
   "ice": {
     "blockshape": "invisible"
   },
+  "magma": {
+    "blockshape": "invisible"
+  },
   "moss_block": {
     "blockshape": "invisible"
   },
   "moss_carpet": {
+    "blockshape": "invisible"
+  },
+  "netherrack": {
     "blockshape": "invisible"
   },
   "podzol": {
@@ -42,10 +57,19 @@
   "snow_layer": {
     "blockshape": "invisible"
   },
+  "soul_sand": {
+    "blockshape": "invisible"
+  },
+  "soul_soil": {
+    "blockshape": "invisible"
+  },
   "stone": {
     "blockshape": "invisible"
   },
   "tuff": {
+    "blockshape": "invisible"
+  },
+  "warped_nylium": {
     "blockshape": "invisible"
   }
 }


### PR DESCRIPTION
This pull request expands the list of blocks configured as invisible in the `resource_packs/fluoroscopy/subpacks/xray/blocks.json` file. These changes are likely intended to enhance the functionality of the xray subpack by making additional block types invisible, improving visibility for users.

**Block invisibility updates:**

* Added the following blocks with `"blockshape": "invisible"`: `basalt`, `blackstone`, `crimson_nylium`, `magma`, `netherrack`, `soul_sand`, `soul_soil`, and `warped_nylium`. [[1]](diffhunk://#diff-b55e6fd36b2bb0333034868be00342fae0bf8451bfe646b858639b476723d660R3-R14) [[2]](diffhunk://#diff-b55e6fd36b2bb0333034868be00342fae0bf8451bfe646b858639b476723d660R33-R44) [[3]](diffhunk://#diff-b55e6fd36b2bb0333034868be00342fae0bf8451bfe646b858639b476723d660R60-R73)